### PR TITLE
Moved test packages to require-dev section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,14 @@
     "homepage": "https://github.com/zachlegih/yarak",
     "minimum-stability": "stable",
     "require": {
-        "phpunit/phpunit": "^5.0",
         "symfony/console": "^3.2",
         "vlucas/phpdotenv": "^2.4",
         "symfony/filesystem": "^3.2",
         "phalcon/zephir": "^0.9.6",
-        "fzaninotto/faker": "^1.6",
+        "fzaninotto/faker": "^1.6"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0",
         "codeception/codeception": "^2.2"
     },
     "autoload": {


### PR DESCRIPTION
Moved test packages to require-dev section of composer.json, since they are required only to develop the package, not to use it